### PR TITLE
internal/testutil: introduce a breaking API change in internal package

### DIFF
--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -23,8 +23,8 @@ type portpair struct {
 // describing it. The port is available for opening when this function returns
 // provided that there is no race by some other code to grab the same port
 // immediately.
-func GetAvailableLocalAddress(tb testing.TB) string {
-	return findAvailable(tb, "tcp4")
+func GetAvailableLocalAddress(tb testing.TB) (string, error) {
+	return findAvailable(tb, "tcp4"), nil
 }
 
 // GetAvailableLocalIPv6Address is IPv6 version of GetAvailableLocalAddress.


### PR DESCRIPTION
This is a test PR, which introduces a breaking API change in the internal packages.

